### PR TITLE
Update base and relative paths for GH Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _site
 Gemfile.lock
+.sass-cache

--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,7 @@ jailed: false
 theme: jekyll-theme-primer
 gfm_quirks: paragraph_end
 repository: adafruit/makecode-newsletter
+baseurl: /makecode-newsletter
 exclude:
     - "_drafts/template.md"
     - "README.md"

--- a/_drafts/2019-09-09-welcome-to-the-makecode-newsletter.md
+++ b/_drafts/2019-09-09-welcome-to-the-makecode-newsletter.md
@@ -8,10 +8,10 @@ categories: weekly
 - [x] change date
 - [x] update title
 - [ ] Feature story
-- [ ] Update [![](/assets/DIR-LOCATION/)]() for images
+- [ ] Update [![](assets/DIR-LOCATION/)]() for images
 - [ ] All images 550w max only
 
-[![MakeCode](/assets/08142019/hero.png)](https://www.makecode.com)
+[![MakeCode](assets/08142019/hero.png)](https://www.makecode.com)
 
 ## The MakeCode Newsletter
 A newsletter devoted to Microsoft MakeCode. News, information, hardware, happenings, and more! Emailed out each month. Sign up [here](https://www.adafruitdaily.com/).
@@ -32,7 +32,7 @@ Microsoft researchers teamed up with designers at the Brooklyn Public Library’
 
 **Lancaster Computer Science student’s research helps New York fashionistas**
 
-[![Lancaster Computer Science student’s research helps New York fashionistas](/assets/09092019/jacdac.jpg)](https://www.lancaster.ac.uk/news/lancaster-computer-science-students-research-helps-new-york-fashionistas)
+[![Lancaster Computer Science student’s research helps New York fashionistas](assets/09092019/jacdac.jpg)](https://www.lancaster.ac.uk/news/lancaster-computer-science-students-research-helps-new-york-fashionistas)
 
 >_"James Devine, a student at Lancaster University’s School of Computing and Communications, has developed a new communication technology called JACDAC that helps different tiny embedded computers known as microcontrollers talk to each other more easily. JACDAC can be described as the USB for the wired Internet of Things (IoT) and simplifies the connecting of microcontrollers featuring different sensors and capabilities. JACDAC enables a network of microcontrollers to work together in highly dynamic environments, yet, makes doing so as simple as plugging a pair of headphones into a 3.5mm socket. Mr. Devine developed JACDAC as part of an internship at Microsoft Research in the United States. His software was originally designed to help develop a multiplayer aspect to Microsoft’s MakeCode Arcade – a web-based application that lets people create their own games for handheld gaming devices."_
 
@@ -44,7 +44,7 @@ Lufkin Independent School District is using Microsoft MakeCode with Adafruit Cir
 
 ## Bots! Robotics Engineering with Hands-On Makerspace Activities
 
-[![Bots Robotics Engineering with Hands-On Makerspace Activities](/assets/09092019/9919botsbook.jpg)](https://nomadpress.net/nomadpress-books/bots-robotics-engineering/)
+[![Bots Robotics Engineering with Hands-On Makerspace Activities](assets/09092019/9919botsbook.jpg)](https://nomadpress.net/nomadpress-books/bots-robotics-engineering/)
 
 **Build and Program a Recycled Robot with MakeCode!** by [Kathy Ceceri](https://twitter.com/KathyCeceri)!
 
@@ -120,7 +120,7 @@ Check out all the MakeCode Arcade game of the week [videos on YouTube](https://w
 
 [BrainPad](https://www.brainpad.com/) at the Detroit Maker Faire - [YouTube](https://youtu.be/AcvoMmHl1DM). Check out all the [BrainPad videos](https://www.youtube.com/channel/UCYvU-GOQCX97aDu3o4bxl_Q/videos).
 
-[![MakeCode Stencils](../assets/09092019/makecode-stencil.png)](https://blog.adafruit.com/2019/08/08/makecode-arcade-stencilr-turn-arcade-images-into-large-stencils-makecode-msmakecode-pelikhan/)
+[![MakeCode Stencils](assets/09092019/makecode-stencil.png)](https://blog.adafruit.com/2019/08/08/makecode-arcade-stencilr-turn-arcade-images-into-large-stencils-makecode-msmakecode-pelikhan/)
 
 Make Stencils using MakeCode Arcade! Via a [Twitter post](https://twitter.com/pelikhan/status/1157366681594822656) by Peli de Halleux, 
 you can use the [MakeCode Arcade Stencilr](https://arcade-stencils.glitch.me/) to turn sprites into painting stencils!
@@ -139,7 +139,7 @@ placeholder text.
 
 ## New guides using MakeCode!
 
-[![2D Sidescrolling Platformer](/assets/09092019/9919complete-2d-platformer-makecode-arcade.gif)](https://www.littlebird.com.au/a/how-to/189/2d-sidescrolling-platformer-with-makecode-arcade)
+[![2D Sidescrolling Platformer](assets/09092019/9919complete-2d-platformer-makecode-arcade.gif)](https://www.littlebird.com.au/a/how-to/189/2d-sidescrolling-platformer-with-makecode-arcade)
 
 [2D Sidescrolling Platformer](https://www.littlebird.com.au/a/how-to/189/2d-sidescrolling-platformer-with-makecode-arcade) with MakeCode Arcade.
 
@@ -194,25 +194,25 @@ Microsoft MakeCode is a free, open source platform for creating engaging compute
 
 **Simulator**
 
-[![Simulator](/assets/08142019/81419sim.jpg)](https://www.microsoft.com/en-us/makecode/about)
+[![Simulator](assets/08142019/81419sim.jpg)](https://www.microsoft.com/en-us/makecode/about)
 
 An interactive simulator provides students with immediate feedback on how their program is running and makes it easy to test and debug their code.
 
 **Block Editor**
 
-[![Block Editor](/assets/08142019/81419block.jpg)](https://www.microsoft.com/en-us/makecode/about)
+[![Block Editor](assets/08142019/81419block.jpg)](https://www.microsoft.com/en-us/makecode/about)
 
 Students new to coding can start with colored blocks that they can drag and drop onto their workspace to construct their programs.
 
 **JavaScript Editor**
 
-[![JavaScript Editor](/assets/08142019/81419jsed.jpg)](https://www.microsoft.com/en-us/makecode/about)
+[![JavaScript Editor](assets/08142019/81419jsed.jpg)](https://www.microsoft.com/en-us/makecode/about)
 
 When they are ready, students can move into a full-featured JavaScript editor with code snippets, tooltips, and error detection to help them.
 
 ## MakeCode Arcade
 
-[![MakeCode Arcade](/assets/08142019/arcade.png)](https://arcade.makecode.com/)
+[![MakeCode Arcade](assets/08142019/arcade.png)](https://arcade.makecode.com/)
 
 Microsoft MakeCode Arcade is a web-based beginner-friendly code editor to create retro arcade games for the web and for microcontrollers. In this guide, you will learn how to assemble your own Arcade hardware from different parts. MakeCode Arcade is open source, and on [GitHub](https://github.com/microsoft/pxt-arcade).
 

--- a/_drafts/template.md
+++ b/_drafts/template.md
@@ -5,7 +5,7 @@ date: 2019-00-00 07:00:00 -0800
 categories: weekly
 ---
 
-[![MakeCode](/assets/08142019/hero.png)](https://www.makecode.com)
+[![MakeCode](assets/08142019/hero.png)](https://www.makecode.com)
 
 ## The MakeCode Newsletter
 A newsletter devoted to Microsoft MakeCode. News, information, happenings, etc. Content for the MakeCode newsletter. Emailed out each month. Sign up [here](https://www.adafruitdaily.com/).
@@ -38,7 +38,7 @@ Check out all the MakeCode Arcade game of the week [videos on YouTube](https://w
 
 ## News from around the web!
 
-[![](/assets/DATE-GOES-HERE-2019/)]()
+[![](assets/DATE-GOES-HERE-2019/)]()
 
 [title](url)
 
@@ -96,25 +96,25 @@ Microsoft MakeCode is a free, open source platform for creating engaging compute
 
 **Simulator**
 
-[![Simulator](/assets/08142019/81419sim.jpg)](https://www.microsoft.com/en-us/makecode/about)
+[![Simulator](assets/08142019/81419sim.jpg)](https://www.microsoft.com/en-us/makecode/about)
 
 An interactive simulator provides students with immediate feedback on how their program is running and makes it easy to test and debug their code.
 
 **Block Editor**
 
-[![Block Editor](/assets/08142019/81419block.jpg)](https://www.microsoft.com/en-us/makecode/about)
+[![Block Editor](assets/08142019/81419block.jpg)](https://www.microsoft.com/en-us/makecode/about)
 
 Students new to coding can start with colored blocks that they can drag and drop onto their workspace to construct their programs.
 
 **JavaScript Editor**
 
-[![JavaScript Editor](/assets/08142019/81419jsed.jpg)](https://www.microsoft.com/en-us/makecode/about)
+[![JavaScript Editor](assets/08142019/81419jsed.jpg)](https://www.microsoft.com/en-us/makecode/about)
 
 When they are ready, students can move into a full-featured JavaScript editor with code snippets, tooltips, and error detection to help them.
 
 ## MakeCode Arcade
 
-[![MakeCode Arcade](/assets/08142019/arcade.png)](https://arcade.makecode.com/)
+[![MakeCode Arcade](assets/08142019/arcade.png)](https://arcade.makecode.com/)
 
 Microsoft MakeCode Arcade is a web-based beginner-friendly code editor to create retro arcade games for the web and for microcontrollers. In this guide, you will learn how to assemble your own Arcade hardware from different parts. MakeCode Arcade is open source, and on [GitHub](https://github.com/microsoft/pxt-arcade).
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,6 +1,6 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns:fb="http://www.facebook.com/2008/fbml" xmlns:og="http://opengraph.org/schema/"> <head>
-<base href="{{ site.url }}" />
+<!DOCTYPE html>
+<html> <head>
+<base href="{{ site.url }}{{ site.baseurl }}/" />
 <meta property="og:title" content="{{ page.title }}"/>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 <meta name="referrer" content="origin" />

--- a/_posts/2019-08-14-welcome-to-the-makecode-newsletter.md
+++ b/_posts/2019-08-14-welcome-to-the-makecode-newsletter.md
@@ -4,7 +4,7 @@ title: "Welcome to the MakeCode newsletter!"
 date: 2019-08-14 07:00:00 -0800
 ---
 
-[![MakeCode](/assets/08142019/hero.png)](https://www.makecode.com)
+[![MakeCode](assets/08142019/hero.png)](https://www.makecode.com)
 
 ## The MakeCode Newsletter
 A newsletter devoted to Microsoft MakeCode. News, information, happenings, etc. Content for the MakeCode newsletter. Emailed out each month. Sign up [here](https://www.adafruitdaily.com/).
@@ -14,25 +14,25 @@ Microsoft MakeCode is a free, open source platform for creating engaging compute
 
 **Simulator**
 
-[![Simulator](/assets/08142019/81419sim.jpg)](https://www.microsoft.com/en-us/makecode/about)
+[![Simulator](assets/08142019/81419sim.jpg)](https://www.microsoft.com/en-us/makecode/about)
 
 An interactive simulator provides students with immediate feedback on how their program is running and makes it easy to test and debug their code.
 
 **Block Editor**
 
-[![Block Editor](/assets/08142019/81419block.jpg)](https://www.microsoft.com/en-us/makecode/about)
+[![Block Editor](assets/08142019/81419block.jpg)](https://www.microsoft.com/en-us/makecode/about)
 
 Students new to coding can start with colored blocks that they can drag and drop onto their workspace to construct their programs.
 
 **JavaScript Editor**
 
-[![JavaScript Editor](/assets/08142019/81419jsed.jpg)](https://www.microsoft.com/en-us/makecode/about)
+[![JavaScript Editor](assets/08142019/81419jsed.jpg)](https://www.microsoft.com/en-us/makecode/about)
 
 When they are ready, students can move into a full-featured JavaScript editor with code snippets, tooltips, and error detection to help them.
 
 ## MakeCode Arcade
 
-[![MakeCode Arcade](/assets/08142019/arcade.png)](https://arcade.makecode.com/)
+[![MakeCode Arcade](assets/08142019/arcade.png)](https://arcade.makecode.com/)
 
 Microsoft MakeCode Arcade is a web-based beginner-friendly code editor to create retro arcade games for the web and for microcontrollers. In this guide, you will learn how to assemble your own Arcade hardware from different parts. MakeCode Arcade is open source, and on [GitHub](https://github.com/microsoft/pxt-arcade).
 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
+    <base href="{{ site.url }}{{ site.baseurl }}/" />
     <title>MakeCode « Adafruit Daily</title>
 		<link rel="alternate" type="application/rss+xml" title="MakeCode Feed" href="/feed.xml">
 		<link rel="stylesheet" id="af-core-css" href="https://www.adafruitdaily.com/app/themes/adafruit2013/style.css?ver=1502388216" type="text/css" media="all">
@@ -30,7 +30,7 @@
           {% endif %} 
           <div class="archive-entry">
             <h4 class="entry-date">{{ post.date | date: "%d" }}</h4>
-            <h4 class="entry-title"><a href="{{ post.url }}">{{ post.title }}</a></h4>
+            <h4 class="entry-title"><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h4>
           </div>
         {% endfor %}
       </div>


### PR DESCRIPTION
I forgot this GH Pages repo will be hosted at https://adafruit.github.io/makecode-newsletter/ rather than its own subdomain.

I've updated asset URLs and relative URLs accordingly. Will require cleanup on assets image references for any content in progress.