### PR TITLE
no baseurl prefix, makecode.adafruitdaily.com

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,6 @@ jailed: false
 theme: jekyll-theme-primer
 gfm_quirks: paragraph_end
 repository: adafruit/makecode-newsletter
-baseurl: /makecode-newsletter
 exclude:
     - "_drafts/template.md"
     - "README.md"

--- a/_drafts/2019-09-09-welcome-to-the-makecode-newsletter.md
+++ b/_drafts/2019-09-09-welcome-to-the-makecode-newsletter.md
@@ -8,10 +8,10 @@ categories: weekly
 - [x] change date
 - [x] update title
 - [ ] Feature story
-- [ ] Update [![](assets/DIR-LOCATION/)]() for images
+- [ ] Update [![](/assets/DIR-LOCATION/)]() for images
 - [ ] All images 550w max only
 
-[![MakeCode](assets/08142019/hero.png)](https://www.makecode.com)
+[![MakeCode](/assets/08142019/hero.png)](https://www.makecode.com)
 
 ## The MakeCode Newsletter
 A newsletter devoted to Microsoft MakeCode. News, information, hardware, happenings, and more! Emailed out each month. Sign up [here](https://www.adafruitdaily.com/).
@@ -32,7 +32,7 @@ Microsoft researchers teamed up with designers at the Brooklyn Public Library’
 
 **Lancaster Computer Science student’s research helps New York fashionistas**
 
-[![Lancaster Computer Science student’s research helps New York fashionistas](assets/09092019/jacdac.jpg)](https://www.lancaster.ac.uk/news/lancaster-computer-science-students-research-helps-new-york-fashionistas)
+[![Lancaster Computer Science student’s research helps New York fashionistas](/assets/09092019/jacdac.jpg)](https://www.lancaster.ac.uk/news/lancaster-computer-science-students-research-helps-new-york-fashionistas)
 
 >_"James Devine, a student at Lancaster University’s School of Computing and Communications, has developed a new communication technology called JACDAC that helps different tiny embedded computers known as microcontrollers talk to each other more easily. JACDAC can be described as the USB for the wired Internet of Things (IoT) and simplifies the connecting of microcontrollers featuring different sensors and capabilities. JACDAC enables a network of microcontrollers to work together in highly dynamic environments, yet, makes doing so as simple as plugging a pair of headphones into a 3.5mm socket. Mr. Devine developed JACDAC as part of an internship at Microsoft Research in the United States. His software was originally designed to help develop a multiplayer aspect to Microsoft’s MakeCode Arcade – a web-based application that lets people create their own games for handheld gaming devices."_
 
@@ -44,7 +44,7 @@ Lufkin Independent School District is using Microsoft MakeCode with Adafruit Cir
 
 ## Bots! Robotics Engineering with Hands-On Makerspace Activities
 
-[![Bots Robotics Engineering with Hands-On Makerspace Activities](assets/09092019/9919botsbook.jpg)](https://nomadpress.net/nomadpress-books/bots-robotics-engineering/)
+[![Bots Robotics Engineering with Hands-On Makerspace Activities](/assets/09092019/9919botsbook.jpg)](https://nomadpress.net/nomadpress-books/bots-robotics-engineering/)
 
 **Build and Program a Recycled Robot with MakeCode!** by [Kathy Ceceri](https://twitter.com/KathyCeceri)!
 
@@ -120,7 +120,7 @@ Check out all the MakeCode Arcade game of the week [videos on YouTube](https://w
 
 [BrainPad](https://www.brainpad.com/) at the Detroit Maker Faire - [YouTube](https://youtu.be/AcvoMmHl1DM). Check out all the [BrainPad videos](https://www.youtube.com/channel/UCYvU-GOQCX97aDu3o4bxl_Q/videos).
 
-[![MakeCode Stencils](assets/09092019/makecode-stencil.png)](https://blog.adafruit.com/2019/08/08/makecode-arcade-stencilr-turn-arcade-images-into-large-stencils-makecode-msmakecode-pelikhan/)
+[![MakeCode Stencils](/assets/09092019/makecode-stencil.png)](https://blog.adafruit.com/2019/08/08/makecode-arcade-stencilr-turn-arcade-images-into-large-stencils-makecode-msmakecode-pelikhan/)
 
 Make Stencils using MakeCode Arcade! Via a [Twitter post](https://twitter.com/pelikhan/status/1157366681594822656) by Peli de Halleux, 
 you can use the [MakeCode Arcade Stencilr](https://arcade-stencils.glitch.me/) to turn sprites into painting stencils!
@@ -133,7 +133,7 @@ See students build the ToddleBot with EV3 LEGO, programmed with MakeCode. [YouTu
 
 MakeCode on a micro:bit controls a Lego robotic arm in this coffee shop build. [YouTube](https://www.youtube.com/watch?v=yhYMkQhljYs&feature=youtu.be)
 
-[![MakeCode Sidescroller Game Tutorial](assets/09092019/9919sidescroller-fame.gif)](https://www.littlebird.com.au/a/how-to/189/2d-sidescrolling-platformer-with-makecode-arcade)
+[![MakeCode Sidescroller Game Tutorial](/assets/09092019/9919sidescroller-fame.gif)](https://www.littlebird.com.au/a/how-to/189/2d-sidescrolling-platformer-with-makecode-arcade)
 
 Tutorials from Little Bird on making a side-scroller platformer game with MakeCode Arcade. [Website](https://www.littlebird.com.au/a/how-to/189/2d-sidescrolling-platformer-with-makecode-arcade)
 
@@ -143,7 +143,7 @@ placeholder text.
 
 ## New guides using MakeCode!
 
-[![2D Sidescrolling Platformer](assets/09092019/9919complete-2d-platformer-makecode-arcade.gif)](https://www.littlebird.com.au/a/how-to/189/2d-sidescrolling-platformer-with-makecode-arcade)
+[![2D Sidescrolling Platformer](/assets/09092019/9919complete-2d-platformer-makecode-arcade.gif)](https://www.littlebird.com.au/a/how-to/189/2d-sidescrolling-platformer-with-makecode-arcade)
 
 [2D Sidescrolling Platformer](https://www.littlebird.com.au/a/how-to/189/2d-sidescrolling-platformer-with-makecode-arcade) with MakeCode Arcade.
 
@@ -198,25 +198,25 @@ Microsoft MakeCode is a free, open source platform for creating engaging compute
 
 **Simulator**
 
-[![Simulator](assets/08142019/81419sim.jpg)](https://www.microsoft.com/en-us/makecode/about)
+[![Simulator](/assets/08142019/81419sim.jpg)](https://www.microsoft.com/en-us/makecode/about)
 
 An interactive simulator provides students with immediate feedback on how their program is running and makes it easy to test and debug their code.
 
 **Block Editor**
 
-[![Block Editor](assets/08142019/81419block.jpg)](https://www.microsoft.com/en-us/makecode/about)
+[![Block Editor](/assets/08142019/81419block.jpg)](https://www.microsoft.com/en-us/makecode/about)
 
 Students new to coding can start with colored blocks that they can drag and drop onto their workspace to construct their programs.
 
 **JavaScript Editor**
 
-[![JavaScript Editor](assets/08142019/81419jsed.jpg)](https://www.microsoft.com/en-us/makecode/about)
+[![JavaScript Editor](/assets/08142019/81419jsed.jpg)](https://www.microsoft.com/en-us/makecode/about)
 
 When they are ready, students can move into a full-featured JavaScript editor with code snippets, tooltips, and error detection to help them.
 
 ## MakeCode Arcade
 
-[![MakeCode Arcade](assets/08142019/arcade.png)](https://arcade.makecode.com/)
+[![MakeCode Arcade](/assets/08142019/arcade.png)](https://arcade.makecode.com/)
 
 Microsoft MakeCode Arcade is a web-based beginner-friendly code editor to create retro arcade games for the web and for microcontrollers. In this guide, you will learn how to assemble your own Arcade hardware from different parts. MakeCode Arcade is open source, and on [GitHub](https://github.com/microsoft/pxt-arcade).
 

--- a/_drafts/template.md
+++ b/_drafts/template.md
@@ -5,7 +5,7 @@ date: 2019-00-00 07:00:00 -0800
 categories: weekly
 ---
 
-[![MakeCode](assets/08142019/hero.png)](https://www.makecode.com)
+[![MakeCode](/assets/08142019/hero.png)](https://www.makecode.com)
 
 ## The MakeCode Newsletter
 A newsletter devoted to Microsoft MakeCode. News, information, happenings, etc. Content for the MakeCode newsletter. Emailed out each month. Sign up [here](https://www.adafruitdaily.com/).
@@ -38,7 +38,7 @@ Check out all the MakeCode Arcade game of the week [videos on YouTube](https://w
 
 ## News from around the web!
 
-[![](assets/DATE-GOES-HERE-2019/)]()
+[![](/assets/DATE-GOES-HERE-2019/)]()
 
 [title](url)
 
@@ -96,25 +96,25 @@ Microsoft MakeCode is a free, open source platform for creating engaging compute
 
 **Simulator**
 
-[![Simulator](assets/08142019/81419sim.jpg)](https://www.microsoft.com/en-us/makecode/about)
+[![Simulator](/assets/08142019/81419sim.jpg)](https://www.microsoft.com/en-us/makecode/about)
 
 An interactive simulator provides students with immediate feedback on how their program is running and makes it easy to test and debug their code.
 
 **Block Editor**
 
-[![Block Editor](assets/08142019/81419block.jpg)](https://www.microsoft.com/en-us/makecode/about)
+[![Block Editor](/assets/08142019/81419block.jpg)](https://www.microsoft.com/en-us/makecode/about)
 
 Students new to coding can start with colored blocks that they can drag and drop onto their workspace to construct their programs.
 
 **JavaScript Editor**
 
-[![JavaScript Editor](assets/08142019/81419jsed.jpg)](https://www.microsoft.com/en-us/makecode/about)
+[![JavaScript Editor](/assets/08142019/81419jsed.jpg)](https://www.microsoft.com/en-us/makecode/about)
 
 When they are ready, students can move into a full-featured JavaScript editor with code snippets, tooltips, and error detection to help them.
 
 ## MakeCode Arcade
 
-[![MakeCode Arcade](assets/08142019/arcade.png)](https://arcade.makecode.com/)
+[![MakeCode Arcade](/assets/08142019/arcade.png)](https://arcade.makecode.com/)
 
 Microsoft MakeCode Arcade is a web-based beginner-friendly code editor to create retro arcade games for the web and for microcontrollers. In this guide, you will learn how to assemble your own Arcade hardware from different parts. MakeCode Arcade is open source, and on [GitHub](https://github.com/microsoft/pxt-arcade).
 

--- a/_posts/2019-08-14-welcome-to-the-makecode-newsletter.md
+++ b/_posts/2019-08-14-welcome-to-the-makecode-newsletter.md
@@ -4,7 +4,7 @@ title: "Welcome to the MakeCode newsletter!"
 date: 2019-08-14 07:00:00 -0800
 ---
 
-[![MakeCode](assets/08142019/hero.png)](https://www.makecode.com)
+[![MakeCode](/assets/08142019/hero.png)](https://www.makecode.com)
 
 ## The MakeCode Newsletter
 A newsletter devoted to Microsoft MakeCode. News, information, happenings, etc. Content for the MakeCode newsletter. Emailed out each month. Sign up [here](https://www.adafruitdaily.com/).
@@ -14,25 +14,25 @@ Microsoft MakeCode is a free, open source platform for creating engaging compute
 
 **Simulator**
 
-[![Simulator](assets/08142019/81419sim.jpg)](https://www.microsoft.com/en-us/makecode/about)
+[![Simulator](/assets/08142019/81419sim.jpg)](https://www.microsoft.com/en-us/makecode/about)
 
 An interactive simulator provides students with immediate feedback on how their program is running and makes it easy to test and debug their code.
 
 **Block Editor**
 
-[![Block Editor](assets/08142019/81419block.jpg)](https://www.microsoft.com/en-us/makecode/about)
+[![Block Editor](/assets/08142019/81419block.jpg)](https://www.microsoft.com/en-us/makecode/about)
 
 Students new to coding can start with colored blocks that they can drag and drop onto their workspace to construct their programs.
 
 **JavaScript Editor**
 
-[![JavaScript Editor](assets/08142019/81419jsed.jpg)](https://www.microsoft.com/en-us/makecode/about)
+[![JavaScript Editor](/assets/08142019/81419jsed.jpg)](https://www.microsoft.com/en-us/makecode/about)
 
 When they are ready, students can move into a full-featured JavaScript editor with code snippets, tooltips, and error detection to help them.
 
 ## MakeCode Arcade
 
-[![MakeCode Arcade](assets/08142019/arcade.png)](https://arcade.makecode.com/)
+[![MakeCode Arcade](/assets/08142019/arcade.png)](https://arcade.makecode.com/)
 
 Microsoft MakeCode Arcade is a web-based beginner-friendly code editor to create retro arcade games for the web and for microcontrollers. In this guide, you will learn how to assemble your own Arcade hardware from different parts. MakeCode Arcade is open source, and on [GitHub](https://github.com/microsoft/pxt-arcade).
 


### PR DESCRIPTION
use `/assets/.../some_image.jpg` for working previews on github and the published github pages at makecode.adafruitdaily.com.