### PR TITLE
hack img src in feed.xml to be absolute

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -11,20 +11,21 @@ layout: null
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>
-    {% for post in site.posts limit:10 %}
+    {% assign srcAssetsAbsolute = 'src="' | append: site.url | append: site.baseurl | append: '/assets' -%}
+    {% for post in site.posts limit:10 -%}
       <item>
         <title>{{ post.title | xml_escape }}</title>
-        <description>{{ post.content | xml_escape }}</description>
+        <description>{{ post.content | replace: 'src="/assets', srcAssetsAbsolute | xml_escape }}</description>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
         <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
         <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
-        {% for tag in post.tags %}
+        {% for tag in post.tags -%}
         <category>{{ tag | xml_escape }}</category>
-        {% endfor %}
-        {% for cat in post.categories %}
+        {%- endfor -%}
+        {% for cat in post.categories -%}
         <category>{{ cat | xml_escape }}</category>
-        {% endfor %}
+        {%- endfor %}
       </item>
-    {% endfor %}
+    {%- endfor %}
   </channel>
 </rss>


### PR DESCRIPTION
MailChimp requires this! https://mailchimp.com/help/common-html-mistakes/#heading+images+and+hyperlinks+don%27t+use+absolute+paths

This is done in the feed template itself by looking for `src="/assets` and rewriting it to include the site's hostname (and path, if any).